### PR TITLE
log player spawned events to event log

### DIFF
--- a/src/PRoCon.Core/Events/CapturableEvents.cs
+++ b/src/PRoCon.Core/Events/CapturableEvents.cs
@@ -6,6 +6,7 @@
         PlayerJoin,
         PlayerLeave,
         PlayerDisconnected,
+        PlayerSpawned,
         PlayerKilled,
         PlayerKicked,
         IPKicked,

--- a/src/PRoCon.Core/Events/EventCaptures.cs
+++ b/src/PRoCon.Core/Events/EventCaptures.cs
@@ -204,6 +204,7 @@ namespace PRoCon.Core.Events
                 this.m_prcClient.Game.PlayerKilledByAdmin += new FrostbiteClient.PlayerKilledByAdminHandler(Game_PlayerKilledByAdmin);
                 this.m_prcClient.Game.PlayerMovedByAdmin += new FrostbiteClient.PlayerMovedByAdminHandler(Game_PlayerMovedByAdmin);
 
+                this.m_prcClient.Game.PlayerSpawned += new FrostbiteClient.PlayerSpawnedHandler(m_prcClient_PlayerSpawned);
                 this.m_prcClient.PlayerKilled += new PRoConClient.PlayerKilledHandler(m_prcClient_PlayerKilled);
                 this.m_prcClient.PunkbusterPlayerUnbanned += new PRoConClient.PunkbusterBanHandler(m_prcClient_PlayerUnbanned);
 
@@ -276,6 +277,13 @@ namespace PRoCon.Core.Events
             if (this.m_prcClient.PlayerList.Contains(strSoldierName) == true)
             {
                 this.ProcessEvent(EventType.Playerlist, CapturableEvents.PlayerSwitchedTeams, strSoldierName, this.m_prcClient.GetLocalizedTeamName(this.m_prcClient.PlayerList[strSoldierName].TeamID, this.m_prcClient.CurrentServerInfo.Map, this.m_prcClient.CurrentServerInfo.GameMode), this.m_prcClient.GetLocalizedTeamName(iTeamID, this.m_prcClient.CurrentServerInfo.Map, this.m_prcClient.CurrentServerInfo.GameMode));
+            }
+        }
+        
+        private void m_prcClient_PlayerSpawned(FrostbiteClient sender, string strSoldierName, string strKit, List<string> lstWeapons, List<string> lstSpecializations)
+        {
+            if (this.m_prcClient.PlayerList.Contains(strSoldierName) == true) {
+                this.ProcessEvent(EventType.Playerlist, CapturableEvents.PlayerSpawned, strSoldierName);
             }
         }
 

--- a/src/Resources/Localization/au.loc
+++ b/src/Resources/Localization/au.loc
@@ -1781,6 +1781,7 @@ uscEvents.gpbCaptures.chkEventsEnableScrolling=Enable scrolling
 uscEvents.lsvEvents.PlayerJoin={0} joined the server
 uscEvents.lsvEvents.PlayerLeave={0} left the server
 uscEvents.lsvEvents.PlayerDisconnected={0} disconnected from the server (reason: {1})
+uscEvents.lsvEvents.PlayerSpawned={0} spawned
 uscEvents.lsvEvents.PlayerKilled={0} killed {1} {2}
 uscEvents.lsvEvents.PlayerKilled.HeadShot=-HEADSHOT-
 uscEvents.lsvEvents.PlayerKicked={0} was kicked from the server

--- a/src/Resources/Localization/de.loc
+++ b/src/Resources/Localization/de.loc
@@ -1739,6 +1739,7 @@ uscEvents.gpbCaptures.chkEventsEnableScrolling=automatisches Scrollen aktivieren
 uscEvents.lsvEvents.PlayerJoin={0} betrat den Server
 uscEvents.lsvEvents.PlayerLeave={0} verließ den Server
 uscEvents.lsvEvents.PlayerDisconnected={0} wurde vom Server getrennt (Grund: {1})
+uscEvents.lsvEvents.PlayerSpawned={0} ist gespawned
 uscEvents.lsvEvents.PlayerKilled={0} killed {1} {2}
 uscEvents.lsvEvents.PlayerKilled.HeadShot=-Kopfschuss-
 uscEvents.lsvEvents.PlayerKicked={0} wurde vom Server geworfen


### PR DESCRIPTION
This pull request adds the logging of player spawn events to the log.
Logging spawns makes tracking certain events easier. E.g. checking the time difference between an admin kill and someone spawning. (E.g. for basecamp etc.)..

Only tested with BF4, but should also work with the other titles.